### PR TITLE
Add run setup script step to gh workflow

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Install Dependences
         run: pip install -r requirements.txt -r requirements-dev.txt
 
+      - name: Run Setup Script
+        run: python setup.py install
+
       - name: Linting
         run: flake8
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 -   repo: https://github.com/pre-commit/mirrors-autopep8
     rev: '4b4928307f1e6e8c9e02570ef705364f47ddb6dc'  # Use the sha / tag you want to point at
     hooks:


### PR DESCRIPTION
@mscheltienne, one more small change to enable using the `mff2mfz.py` script in the test workflow. If it looks good to you, please merge with your branch and then I will merge with ours.